### PR TITLE
Deprecation and URL fix

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,14 +1,14 @@
 In this repo you will also find some examples of how to use the Forecast-API (this is a work in progress still).  
 
 Python:  
-* [point_time.py](examples-py/point_time.py) shows you the response for a basic point time response
-* [point_time_masks.py](examples-py/point_time_masks.py) shows you how to deal with masks / no-data values and the reason for why data was NULL.
-* [point_time_units.py](examples-py/point_time_units.py) basic unit converstion for the variable's data.
-* [point_time_wind_vectors.py](examples-py/point_time_wind_vectors.py) how to convert vectors like wind and ocean currents into magnitude and direction.
-* [point_time_rain.py](examples-py/point_time_rain.py) derives the chances of rain to text from the variable `precipitation.rate`.
+* [point_time.py](python/point_time.py) shows you the response for a basic point time response
+* [point_time_masks.py](python/point_time_masks.py) shows you how to deal with masks / no-data values and the reason for why data was NULL.
+* [point_time_units.py](python/point_time_units.py) basic unit converstion for the variable's data.
+* [point_time_wind_vectors.py](python/point_time_wind_vectors.py) how to convert vectors like wind and ocean currents into magnitude and direction.
+* [point_time_rain.py](python/point_time_rain.py) derives the chances of rain to text from the variable `precipitation.rate`.
 
 To run the examples you will need to set the ENV `apikey` e.g.
 ```
-apikey=MYAPIKEY python3 examples-py/point_time_wind_vectors.py
+apikey=MYAPIKEY python3 python/point_time_wind_vectors.py
 ```
 

--- a/python/point_time.py
+++ b/python/point_time.py
@@ -1,6 +1,6 @@
 from requests import post
 from os import getenv
-from datetime import datetime
+from datetime import datetime, timezone
 import json
 
 
@@ -17,7 +17,7 @@ resp = post(
             "cloud.cover"
         ],
         "time": {
-            "from": "{:%Y-%m-%dT00:00:00Z}".format(datetime.utcnow()),
+            "from": "{:%Y-%m-%dT00:00:00Z}".format(datetime.now(timezone.utc)),
             "interval": "3h",
             "repeat": 2
         }

--- a/python/point_time_masks.py
+++ b/python/point_time_masks.py
@@ -2,7 +2,7 @@ from requests import post
 from numpy import float64
 from numpy.ma import masked_array
 from os import getenv
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 # Below is an example of selecting two geographical points, one in the ocean -37.7935, 174.7842 and the other on
@@ -28,7 +28,7 @@ resp = post(
             "wave.height"
         ],
         "time": {
-            "from": "{:%Y-%m-%dT00:00:00Z}".format(datetime.utcnow()),
+            "from": "{:%Y-%m-%dT00:00:00Z}".format(datetime.now(timezone.utc)),
             "interval": "3h",
             "repeat": 2
         }

--- a/python/point_time_rain.py
+++ b/python/point_time_rain.py
@@ -2,13 +2,13 @@ from requests import post
 from numpy import float64
 from numpy.ma import masked_array, is_masked
 from os import getenv
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 # NOTE: don't for get to set "apikey" env, or the default below.
 resp = post(
     "https://forecast-v2.metoceanapi.com/point/time",
-    headers={"x-api-key": getenv("apikey", "MYAPIKEY")},
+    headers={"x-api-key": getenv("METSERVICE_API_KEY", "MYAPIKEY")},
     json={
         "points": [{
           "lon": 174.7842,
@@ -18,7 +18,7 @@ resp = post(
             "precipitation.rate"
         ],
         "time": {
-            "from": "{:%Y-%m-%dT00:00:00Z}".format(datetime.utcnow()),
+            "from": "{:%Y-%m-%dT00:00:00Z}".format(datetime.now(timezone.utc)),
             "interval": "3h",
             "repeat": 2
         }

--- a/python/point_time_units.py
+++ b/python/point_time_units.py
@@ -2,7 +2,7 @@ from requests import post
 from numpy import float64
 from numpy.ma import masked_array
 from os import getenv
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 # NOTE: don't for get to set "apikey" env, or the default below.
@@ -18,7 +18,7 @@ resp = post(
             "air.temperature.at-2m"
         ],
         "time": {
-            "from": "{:%Y-%m-%dT00:00:00Z}".format(datetime.utcnow()),
+            "from": "{:%Y-%m-%dT00:00:00Z}".format(datetime.now(timezone.utc)),
             "interval": "3h",
             "repeat": 2
         }

--- a/python/point_time_units_by_lookup.py
+++ b/python/point_time_units_by_lookup.py
@@ -2,7 +2,7 @@ from requests import Session
 from numpy import float64
 from numpy.ma import masked_array
 from os import getenv
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 def _convert_units(data, src_units: str, dst_units: str, units_list: dict):
@@ -38,7 +38,7 @@ def _main():
                     "air.temperature.at-2m"
                 ],
                 "time": {
-                    "from": "{:%Y-%m-%dT00:00:00Z}".format(datetime.utcnow()),
+                    "from": "{:%Y-%m-%dT00:00:00Z}".format(datetime.now(timezone.utc)),
                     "interval": "3h",
                     "repeat": 2
                 }

--- a/python/point_time_wind_vectors.py
+++ b/python/point_time_wind_vectors.py
@@ -2,7 +2,7 @@ from requests import post
 from numpy import float64, pi
 from numpy.ma import masked_array, mod, arctan2, sqrt, power
 from os import getenv
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 # NOTE: don't for get to set "apikey" env, or the default below.
@@ -19,7 +19,7 @@ resp = post(
             "wind.speed.eastward.at-10m"
         ],
         "time": {
-            "from": "{:%Y-%m-%dT00:00:00Z}".format(datetime.utcnow()),
+            "from": "{:%Y-%m-%dT00:00:00Z}".format(datetime.now(timezone.utc)),
             "interval": "3h",
             "repeat": 2
         }


### PR DESCRIPTION
Hello,

This is just a small fix for two things:

- Update the paths to the example scripts in the README
- Replace the deprecated `datetime.datetime.utcnow` function. Removes the following warning:

```
DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
```

Cheers